### PR TITLE
[See description]

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ It also shows (in orange) the number of operations that are in-flight at the mom
 
 ## Keys
 
-Press ESCAPE to stop diskgraph.
+Press ESCAPE or Q to exit diskgraph.
 
 ## Known issues
 


### PR DESCRIPTION
Used a better way to get the terminal size
Fixed not resetting shell prompt position to beginning of line
Added 'q' as an exit key
Improved legibility a bit by adding spacing between arithmetic operators
Changed _WIN64 to _WIN32 to fix compiling on 32-bit Windows (_WIN32 is also defined under 64-bit Windows)
Made a dummy functions for raw mode functions under Windows as CMD doesn't echo characters
Fixed possible ENABLE_VIRTUAL_TERMINAL_PROCESSING undefined issue on Windows
Added a lot more _WIN32 checks to exclude things that are missing on Windows
Windows polls the size now due to the absence of SIGWINCH