### PR TITLE
Fix overflow in `setup_image()`

### DIFF
--- a/diskgraph.c
+++ b/diskgraph.c
@@ -65,7 +65,7 @@ static void setup_image(void)
 
 	imw = termw;
 	imh = 2 * (termh-1);
-	const size_t sz = imw * imh * 4;
+	const size_t sz = 4ull * imw * imh;
 	im = (uint32_t*) malloc(sz);
 	memset( im, 0x00, sz );
 


### PR DESCRIPTION
Sometimes, when piping diskgraph's output through other programs, reported terminal size gets quite high (50 thousand by 40 thousand something). This is definitely not the best fix in the world, but at least it prevents multiplication overflow, which leads to insanely high size in `const size_t sz = imw * imh * 4;` and further crash with SIGSEGV.