### PR TITLE
Avoid exiting on escape sequences

### DIFF
--- a/diskgraph.c
+++ b/diskgraph.c
@@ -404,8 +404,20 @@ int main( int argc, char* argv[] )
 
 		char c;
 		const int numr = read( STDIN_FILENO, &c, 1 );
-		if ( numr == 1 && ( c == 27 || c == 'q' || c == 'Q' ) )
-			done = 1;
+		if ( numr == 1 )
+		{
+			if ( c == 27 )
+			{
+				char seq[16];
+				const ssize_t extra = read( STDIN_FILENO, seq, sizeof(seq) );
+				if ( extra <= 0 )
+					done = 1;
+			}
+			else if ( c == 'q' || c == 'Q' )
+			{
+				done = 1;
+			}
+		}
 
 		int hsz = histsz();
 		int overflow_bw = 0;


### PR DESCRIPTION
**Summary:** Adjust _diskgraph_ input handling so the app ignores multi-byte escape sequences (arrow keys, mouse events) and only quits on standalone ESC or q/Q.

**Details:** When a 27 byte arrives, the program now attempts to read additional bytes from stdin. If none follow, the user pressed plain ESC and we exit; otherwise we treat it as part of a control sequence and continue without terminating.

**Testing:** Tested manually in a terminal session to confirm that arrow keys and mouse events no longer terminate the program, while ESC and q/Q still exit as expected.