### PR TITLE
Improve Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,44 +1,61 @@
 CC ?= cc
 CFLAGS += -D_POSIX_C_SOURCE=199309L -std=c99 -Wall -Wextra
-LDFLAGS +=
+LDFLAGS += -lm
 
 TARGET = diskgraph
+MANPAGE = $(TARGET).1
 SRC = diskgraph.c
 OBJ = $(SRC:.c=.o)
 
-DISTFILES=\
-Makefile \
-diskgraph.c \
-diskgraph.1 \
-README.md \
-LICENSE \
-images \
-debian
+# Installation paths
+PREFIX ?= /usr/local
+BINDIR = $(PREFIX)/bin
+MANDIR = $(PREFIX)/share/man/man1
 
-all:	$(TARGET)
+# Distribution files
+DISTFILES = \
+	Makefile \
+	$(SRC) \
+	$(MANPAGE) \
+	README.md \
+	LICENSE \
+	images \
+	debian
 
-$(TARGET):	$(OBJ)
+# Version for Debian packaging
+VERSION = 1.2
+DEB_RELEASE = 1
+PPA = ppa:b-stolk/ppa
+
+.PHONY: all clean install uninstall tarball packageupload
+
+all: $(TARGET)
+
+$(TARGET): $(OBJ)
 	$(CC) $(CFLAGS) -o $(TARGET) $(OBJ) $(LDFLAGS)
 
-.c.o:
+%.o: %.c
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	$(RM) *.o $(TARGET)
+	rm -f $(OBJ) $(TARGET)
 	@echo All clean
 
-install: diskgraph
-	install -d ${DESTDIR}/usr/bin
-	install -m 755 diskgraph ${DESTDIR}/usr/bin/
+install: $(TARGET)
+	install -d $(DESTDIR)$(BINDIR)
+	install -d $(DESTDIR)$(MANDIR)
+	install -m 755 $(TARGET) $(DESTDIR)$(BINDIR)/
+	install -m 644 $(MANPAGE) $(DESTDIR)$(MANDIR)/
 
 uninstall:
-	rm -f ${DESTDIR}/usr/bin/distgraph
+	rm -f $(DESTDIR)$(BINDIR)/$(TARGET)
+	rm -f $(DESTDIR)$(MANDIR)/$(MANPAGE)
 
 tarball:
-	tar cvzf ../diskgraph_1.2.orig.tar.gz $(DISTFILES)
+	@echo Creating tarball in parent directory (required for Debian packaging)...
+	tar cvzf ../$(TARGET)_$(VERSION).orig.tar.gz $(DISTFILES)
 
 packageupload:
 	debuild -S
-	debsign ../diskgraph_1.2-1_source.changes
-	dput --force ppa:b-stolk/ppa ../diskgraph_1.2-1_source.changes
-
+	debsign ../$(TARGET)_$(VERSION)-$(DEB_RELEASE)_source.changes
+	dput --force $(PPA) ../$(TARGET)_$(VERSION)-$(DEB_RELEASE)_source.changes


### PR DESCRIPTION
- Fix typo in uninstall target **distgraph** to **diskgraph**.
- Install man page to the correct location.
- Add configurable installation paths PREFIX, BINDIR, MANDIR.
- Link with math library (-lm).
- Replace hardcoded values with variables VERSION, DEB_RELEASE, PPA, MANPAGE, SRC.
- Update pattern rule syntax **.c.o:** to **%.o: %.c**.
- Improve clean target to use $(OBJ) instead of *.o.